### PR TITLE
Add option to enable/disable logging of invalid nesting.

### DIFF
--- a/app/code/community/Aoe/Profiler/etc/config.xml
+++ b/app/code/community/Aoe/Profiler/etc/config.xml
@@ -34,6 +34,7 @@
 			<debug>
 				<showDisabledMessage>1</showDisabledMessage>
 				<hideLinesFasterThan>10</hideLinesFasterThan>
+				<logInvalidNesting>1</logInvalidNesting>
 			</debug>
 		</dev>
 	</default>

--- a/app/code/community/Aoe/Profiler/etc/system.xml
+++ b/app/code/community/Aoe/Profiler/etc/system.xml
@@ -31,6 +31,16 @@
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
 						</hideLinesFasterThan>
+						<logInvalidNesting translate="label comment">
+							<label>Log invalid nesting</label>
+							<comment><![CDATA[Write information to system log when buckets are not started / stopped in correct order.]]></comment>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>120</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</logInvalidNesting>
 					</fields>
 				</debug>
 			</groups>

--- a/app/code/community/Varien/Profiler.php
+++ b/app/code/community/Varien/Profiler.php
@@ -92,14 +92,18 @@ class Varien_Profiler {
 
 		$currentName = end(self::$stack);
 		if ($currentName != $name) {
-			Mage::log('[INVALID NESTING!] Found: ' .$name . " | Expecting: $currentName");
+		    if (Mage::getStoreConfigFlag('dev/debug/logInvalidNesting')) {
+			    Mage::log('[INVALID NESTING!] Found: ' .$name . " | Expecting: $currentName");
+            }
 
 			if (in_array($name, self::$stack)) {
 				// trying to stop something that has been started before,
 				// but there are other unstopped stack items
 				// -> auto-stop them
 				while (($latestStackItem = end(self::$stack)) != $name) {
-					Mage::log('Auto-stopping timer "' .$latestStackItem . '" because of incorrect nesting');
+				    if (Mage::getStoreConfigFlag('dev/debug/logInvalidNesting')) {
+					   Mage::log('Auto-stopping timer "' .$latestStackItem . '" because of incorrect nesting');
+                    }
 					self::stop($latestStackItem);
 				}
 			} else {


### PR DESCRIPTION
Some Magento installations tend to have invalid nestings on every single page. (I have to verify if this also happens for vanilla installations). However, this can bloat system.log rapidly when used on production systems.

I added the option to enable/disable the logging of invalid nesting. By default, the logging is enabled so default behaviour doesn't change.

I didn't bump the version number in case you want to do that.
