### PR TITLE
For some of our ajax calls, ['args'][2] does not exist at some level of the backtrace

### DIFF
--- a/app/code/community/Varien/Profiler.php
+++ b/app/code/community/Varien/Profiler.php
@@ -82,7 +82,11 @@ class Varien_Profiler {
 			$trace = debug_backtrace();
 			$className = get_class($trace[1]['args'][0]);
 			$entityId = $trace[1]['args'][1];
-			$attributes = $trace[1]['args'][2];
+			if (count($trace[1]['args']) >= 3) {
+				$attributes = $trace[1]['args'][2];
+			} else {
+				$attributes = null;
+			}
 			self::$stackLog[$currentPointer]['detail'] = "$className, id: $entityId, attributes: " . var_export($attributes, true);
 		}
 


### PR DESCRIPTION
i'm not sure if this is the best fix for the problem, but prevents it from Noticing.  might only be an issue in php 5.3 and lower?
