### PR TITLE
Quick patch undefined  in Varien Profiler

### DIFF
--- a/app/code/community/Varien/Profiler.php
+++ b/app/code/community/Varien/Profiler.php
@@ -181,7 +181,7 @@ class Varien_Profiler
             self::$stackLog[$currentPointer]['detail'] = "$className, id: $entityId, attributes: " . var_export($attributes, true);
         }
 
-        if (self::getConfiguration()->captureBacktraces) {
+        if (!empty(self::getConfiguration()->captureBacktraces)) {
             $trace = isset($trace) ? $trace : debug_backtrace();
             $fileAndLine = self::getFileAndLine($trace, $type, $name);
             self::$stackLog[$currentPointer]['file'] = $fileAndLine['file'];

--- a/app/code/community/Varien/Profiler.php
+++ b/app/code/community/Varien/Profiler.php
@@ -521,7 +521,7 @@ class Varien_Profiler
     {
         $conf = self::getConfiguration();
         $totals = self::getTotals();
-        return !$conf->enableFilters || (!$conf->filters->timeThreshold || $totals['time'] > $conf->filters->timeThreshold) &&
+        return empty($conf->enableFilters) || (!$conf->filters->timeThreshold || $totals['time'] > $conf->filters->timeThreshold) &&
                (!$conf->filters->memoryThreshold || $totals['realmem'] > $conf->filters->memoryThreshold);
     }
 


### PR DESCRIPTION
This pull fixes an issue where, when developer mode is enabled, $captureBacktraces and conf->enableFilters throw a notice; e.g.:

```

Notice: Undefined property: stdClass::$captureBacktraces in /Users/pjackson/Desktop/Aoe_Profiler/app/code/community/Varien/Profiler.php on line 184
Notice: Undefined property: stdClass::$captureBacktraces  in /Users/pjackson/Desktop/Aoe_Profiler/app/code/community/Varien/Profiler.php on line 184

#0 /Users/pjackson/Desktop/Aoe_Profiler/app/code/community/Varien/Profiler.php(184): mageCoreErrorHandler(8, 'Undefined prope...', '/Users/pjackson...', 184, Array)
#1 /Users/pjackson/Desktop/autocompleteplus/trunk/app/code/core/Mage/Core/Model/App.php(379): Varien_Profiler::start('mage::app::init...')
#2 /Users/pjackson/Desktop/autocompleteplus/trunk/app/code/core/Mage/Core/Model/App.php(293): Mage_Core_Model_App->_initBaseConfig()
#3 /Users/pjackson/Desktop/autocompleteplus/trunk/app/code/core/Mage/Core/Model/App.php(337): Mage_Core_Model_App->baseInit(Array)
#4 /Users/pjackson/Desktop/autocompleteplus/trunk/app/Mage.php(684): Mage_Core_Model_App->run(Array)
#5 /Users/pjackson/Desktop/autocompleteplus/trunk/index.php(87): Mage::run('', 'store')
#6 /Users/pjackson/Desktop/autocompleteplus/trunk/router.php(10): include_once('/Users/pjackson...')
#7 {main}
```