### PR TITLE
fix div by zero by workaround

### DIFF
--- a/app/code/community/Aoe/Profiler/Model/Run.php
+++ b/app/code/community/Aoe/Profiler/Model/Run.php
@@ -132,9 +132,17 @@ class Aoe_Profiler_Model_Run extends Mage_Core_Model_Abstract
                     if (!isset($this->stackLog[$key][$metric . '_' . $column])) {
                         continue;
                     }
-                    $this->stackLog[$key][$metric . '_rel_' . $column] = $this->stackLog[$key][$metric . '_' . $column] / $this->stackLog['timetracker_0'][$metric . '_total'];
+                    if($this->stackLog['timetracker_0'][$metric . '_total'] > 0) {
+                        $this->stackLog[$key][$metric . '_rel_' . $column] = $this->stackLog[$key][$metric . '_' . $column] / $this->stackLog['timetracker_0'][$metric . '_total'];
+                    } else {
+                        $this->stackLog[$key][$metric . '_rel_' . $column] = 0;
+                    }
                 }
-                $this->stackLog[$key][$metric . '_rel_offset'] = $this->stackLog[$key][$metric . '_start_relative'] / $this->stackLog['timetracker_0'][$metric . '_total'];
+                if($this->stackLog['timetracker_0'][$metric . '_total'] > 0) {
+                    $this->stackLog[$key][$metric . '_rel_offset'] = $this->stackLog[$key][$metric . '_start_relative'] / $this->stackLog['timetracker_0'][$metric . '_total'];
+                } else {
+                    $this->stackLog[$key][$metric . '_rel_offset'] = 0;
+                }
             }
         }
     }

--- a/app/code/community/Aoe/Profiler/etc/config.xml
+++ b/app/code/community/Aoe/Profiler/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Aoe_Profiler>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
         </Aoe_Profiler>
     </modules>
 


### PR DESCRIPTION
I am not entirely sure what causes the zero'd values, as I did not dig that deep.

Randomly, $this->stackLog['timetracker_0'][$metric . '_total'] is null or zero, so I bypassed teh issue by detecting this, and then setting the wanted result values to 0 (since we want to div by 0)

I have not used the module long enough to see what issue this causes, but the error itself is obviously gone.

Interesting is that this only started after session were set to Redix via 

https://github.com/colinmollenhour/Cm_RedisSession

This is a loose assumption, not specifically tested, but all was fine until it was added.
